### PR TITLE
Full token list (#33)

### DIFF
--- a/components/Page.js
+++ b/components/Page.js
@@ -35,12 +35,6 @@ function Page() {
     }
   }, []);
 
-  // Being undone by new conditional in actions.refreshUser(); is it necessary here?
-  console.log("Ostate user balance from Page.js:", ostate.user.balances);
-  useEffect(() => {
-    if (ostate.user.balances.length === 0) actions.refreshUser();
-  }, [ostate.user.balances, ostate.user]);
-
   return (
     <>
       <Head>

--- a/components/upload/SelectCurrency.js
+++ b/components/upload/SelectCurrency.js
@@ -1,40 +1,23 @@
 import React, { useEffect } from "react";
-import PropTypes from "prop-types";
 
-const SelectCurrency = ({ currencies, onSelectCurrency }) => {
-  currencies.sort((a, b) =>
-    parseFloat(a.decAmount) < parseFloat(b.decAmount) ? 1 : -1
-  );
+const SelectCurrency = ({ tokens, onSelectCurrency }) => {
 
-  const filteredCurrencies = currencies.filter(
-    (currency) => currency.code !== "AUD"
-  );
-
-  useEffect((x) => {
-    // relay default setting up to parent
-    onSelectCurrency(filteredCurrencies[0].code);
-  }, []);
+  if (tokens == []) return null;
 
   return (
     <select
       className="justify-center my-1 bg-white hover:bg-gray-400 text-black font-semibold w-30 py-2 px-4 border-2 border-gray-400 rounded shadow m-1"
       onChange={(e) => onSelectCurrency(e.target.value)}
     >
-      {filteredCurrencies.map((currency) => {
-        const { code, name } = currency;
+      {tokens.map((t) => {
         return (
-          <option key={code} value={code}>
-            {name}
+          <option key={t} value={t}>
+            {t}
           </option>
         );
       })}
     </select>
   );
-};
-
-SelectCurrency.propTypes = {
-  currencies: PropTypes.array.isRequired,
-  onSelectCurrency: PropTypes.func.isRequired,
 };
 
 export default SelectCurrency;

--- a/components/upload/UploadTokenMenu.js
+++ b/components/upload/UploadTokenMenu.js
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from "react";
-// import data from "../data/Data";
 import SelectCurrency from "./SelectCurrency";
 import Slider from "@material-ui/core/Slider";
-
 import OutlinedInput from "@material-ui/core/OutlinedInput";
 import Input from "@material-ui/core/Input";
 import FormHelperText from "@material-ui/core/FormHelperText";
@@ -16,8 +14,6 @@ export default function App({ tokens, onChange }) {
 
   const [state, setState] = useState({});
 
-  tokens = tokens || [];
-
   useEffect(
     (x) => {
       onChange(state);
@@ -25,32 +21,12 @@ export default function App({ tokens, onChange }) {
     [state]
   );
 
-  const data = {
-    currencies: tokens.map((t) => ({
-      code: t.token.symbol,
-      sellRate: 1,
-      decAmount: t.decAmount,
-      name: t.token.symbol + " Token",
-    })),
-    fiat: [
-      {
-        code: "USD",
-        sellRate: 0.7041,
-        name: "United States Dollars",
-      },
-    ],
-  };
-
   function onSelectCurrency(idx, x, val) {
-    // console.log("x", idx, x, val);
     const y = { ...state };
-
     y[idx] = y[idx] || {};
-
     if (x) {
       y[idx] = { ...y[idx], name: x, amount: 1 || y[idx].amount };
     }
-
     if (val) {
       val = parseFloat(val);
       y[idx] = { ...y[idx], amount: val };
@@ -73,8 +49,6 @@ export default function App({ tokens, onChange }) {
       return y;
     });
   }
-
-  // console.log("state", state);
 
   return (
     <div className="w-screen">
@@ -105,7 +79,7 @@ export default function App({ tokens, onChange }) {
             endAdornment={
               <InputAdornment position="end">
                 <SelectCurrency
-                  currencies={data.currencies}
+                  tokens={tokens}
                   onSelectCurrency={(d) => onSelectCurrency(x, d)}
                 />
               </InputAdornment>

--- a/pages/post/[slug].js
+++ b/pages/post/[slug].js
@@ -109,18 +109,20 @@ export default function Slug() {
     setState((x) => ({ ...x, unlocked: true }));
   }
 
-  useEffect(() => {
-    actions.refreshUser(videoObj.tokenName);
-  }, [videoObj.tokenName]);
-
-  //console.log("Token required for video:", videoObj.tokenName)
-  //console.log("Amount of tokens required:", videoObj.tokens)
-  console.log("Balance in ostate:", ostate.user.balances);
-
 // Could these be replaced/refactored with the corresponding values in Ostate? 
 // Better in local to compare for useEffect changes?
   let hasEnough = false;
   let balance = 0;
+
+  useEffect(() => {
+    actions.refreshUser(videoObj.tokenName);
+
+    return () => { actions.resetBalance(0); }
+  }, [videoObj.tokenName]);
+
+  //console.log("Token required for video:", videoObj.tokenName)
+  //console.log("Amount of tokens required:", videoObj.tokens)
+  //console.log("Balance in ostate:", ostate.user.balances);
 
   if (ostate.user.balances.length > 0 && videoObj.tokenName) {
     if (Roll.checkForRoll()) {

--- a/pages/test2.js
+++ b/pages/test2.js
@@ -38,10 +38,8 @@ export default function Tabs({ color="black", data }) {
 
   const address = useAddress();
 
-  console.log("Fetch data:", data);
-
 // This is why balances don't show after ostate changes: if (ostate.user.balances.length === 0)
-console.log("Ostate user balance from upload.js:", ostate.user.balances);
+//console.log("Ostate user balance from test2.js:", ostate.user.balances);
   useEffect(() => {
     if (ostate.user.balances.length === 0) actions.refreshUser();
   }, [ostate.user.balances, ostate.user]);
@@ -260,15 +258,13 @@ console.log("Ostate user balance from upload.js:", ostate.user.balances);
                                 accept="video/*;capture=camcorder"
                               />
 
-                              {ostate.user.balances.length > 0 && (
+                              
                                 <SetTicket
-                                  tokens={ostate.user.balances}
+                                  tokens={data}
                                   onChange={onTokenChange}
                                 ></SetTicket>
-                              )}
-                              {ostate.user.balances.length === 0 && (
-                                <p>You currently do not have any tokens</p>
-                              )}
+                              
+                              
 
                               <button
                                 onClick={onSubmit}

--- a/pages/upload.js
+++ b/pages/upload.js
@@ -3,7 +3,8 @@ import Page from "../components/Page";
 import { TextField, Slider, Typography, Button } from "@material-ui/core";
 import { addVideo } from "../utils/CTS3";
 import { Alert, AlertTitle } from "@material-ui/lab";
-// import { createGif } from "../utils/GifUtil";
+import axios from "axios";
+import { ethers } from "ethers";
 import LoadingOverlay from "../components/LoadingOverlay";
 import { Icon, InlineIcon } from "@iconify/react";
 import cloudUploadAltSolid from "@iconify/icons-la/cloud-upload-alt-solid";
@@ -17,8 +18,9 @@ import MetaMask from "../components/MetaMask";
 import blueConfirmation from "../src/lotties/blueConfirmation";
 import CloseOut from "../components/closeOut";
 import ExternalContentSubmitForm from "../components/upload/ExternalContentSubmitForm";
+import * as Wallet from "../utils/Web3Wallet";
 
-const Tabs = ({ color }) => {
+export default function Tabs({ color="black", data }) {
   const [openTab, setOpenTab] = React.useState(1);
   const [state, setState] = useState({ progress: 0 });
   const [formdata, setFormData] = useState({ tokens: 1 });
@@ -35,12 +37,6 @@ const Tabs = ({ color }) => {
   };
 
   const address = useAddress();
-
-// This is why balances don't show after ostate changes: if (ostate.user.balances.length === 0)
-console.log("Ostate user balance from upload.js:", ostate.user.balances);
-  useEffect(() => {
-    if (ostate.user.balances.length === 0) actions.refreshUser();
-  }, [ostate.user.balances, ostate.user]);
 
   async function onSubmit() {
     const _files = hiddenFileInput.current; // document.getElementById("videoupload");
@@ -117,7 +113,7 @@ console.log("Ostate user balance from upload.js:", ostate.user.balances);
     setFormData((x) => ({ ...x, tokens }));
   }
 
-  if (!address) {
+  if (!address && !data) {
     return <MetaMask></MetaMask>;
   }
 
@@ -255,17 +251,10 @@ console.log("Ostate user balance from upload.js:", ostate.user.balances);
                                 name="myfile"
                                 accept="video/*;capture=camcorder"
                               />
-
-                              {ostate.user.balances.length > 0 && (
-                                <SetTicket
-                                  tokens={ostate.user.balances}
-                                  onChange={onTokenChange}
-                                ></SetTicket>
-                              )}
-                              {ostate.user.balances.length === 0 && (
-                                <p>You currently do not have any tokens</p>
-                              )}
-
+                              <SetTicket
+                                tokens={data}
+                                onChange={onTokenChange}
+                              />                            
                               <button
                                 onClick={onSubmit}
                                 className="overflow-visible mb-8 mt-4 w-full h-12 bg-black rounded-lg hover:bg-gray-700 text-white font-semibold rounded shadow-lg sm:h-16"
@@ -293,10 +282,10 @@ console.log("Ostate user balance from upload.js:", ostate.user.balances);
   );
 };
 
-export default function TabsRender() {
-  return (
-    <>
-      <Tabs color="black" />;
-    </>
-  );
+export async function getStaticProps() {
+  const data = await Wallet.listRollTokens();
+  return {
+    props: { data },
+    revalidate: 3600
+  }
 }

--- a/stores/Overmind.js
+++ b/stores/Overmind.js
@@ -44,7 +44,7 @@ export const overmind = createOvermind(
         
         state.user.isAuthenticated = true;
         actions.updateUser(user);
-        console.log("Final user in ostate", user);  
+        //console.log("Final user in ostate", user);  
       },
       updateUser({ state }, user) {
         if (!user) return;
@@ -74,6 +74,9 @@ export const overmind = createOvermind(
         if (state.user.wallets.address) {
           state.user.isAuthenticated = true;
         }
+      },
+      resetBalance({ state }, balance) {
+        state.user.balances = balance;
       },
       updateStep({ state }, step) {
         state.currentStep = step;


### PR DESCRIPTION
- Makes the full token list on the Roll Uniswap exchange available for users to choose from when setting a token for video uploads.

- Some refactoring and reorganizing in the SelectCurrency.js and UploadTokenMenu.js since the logic for getting user balance data to populate the token list is no longer necessary.

- Fixed the "slow connection" exploit by adding a reset state action in Overmind and using it as useEffect cleanup function in [slug].js.

- Using Next's static site regeneration (I'm pretty sure it's working) to retrieve the token list data server side and revalidate the data every hour. Could change the frequency of this if needed. This is all in upload.js.